### PR TITLE
Add file name to toolbar

### DIFF
--- a/main.css
+++ b/main.css
@@ -198,10 +198,20 @@ li #faq {
     color: #fff;
     font-family: 'bebas';
     font-size: 18px;
-    margin: 22px 15px 0px 4px;
+    margin: 20px 15px 0px 40px;
     display: inline-block; 
     vertical-align:middle;
     cursor:pointer;
+}
+.navbar #conlluFileNameDiv {
+    margin: 10px 15px 10px 4px;
+}
+
+.navbar #conlluFileName {
+    color: #fff;
+    font-family: 'bebas';
+    font-size: 14px;
+    width: 200%;
 }
 
 /* navigation menu links */
@@ -348,14 +358,15 @@ body.viewtree {
 
 /* toolbar div boxes alignment */
 .btn-initial{
-    width:20%;
+    /* width:20%; */
     margin-left: 10px;
 }
 .btn-initial input{
     margin-right: 20px
 }
+
 .btn-nav{
-    width:40%;
+    width:30%;
 }
 .btn-nav input {
     font-size: 20px;

--- a/main.js
+++ b/main.js
@@ -678,7 +678,8 @@ var convertToJSON = function(inputData) {
 var setJSONtreeData = function() {
     
     var x = document.getElementById('inputFile');
-
+    var file_name_elem = document.getElementById("conlluFileName");
+    var output_file_name_elem = document.getElementById("filename");
     if ('files' in x) {
         if (x.files.length == 0) {
             alert('Please select one or more files, or use use the Upload button in the sentence uploader section.');
@@ -686,6 +687,8 @@ var setJSONtreeData = function() {
             readConfigFile();
             for (var i = 0; i < x.files.length; i++) {
                 var file = x.files[i];
+                file_name_elem.innerHTML = file.name.split('.')[0];
+                output_file_name_elem.value = file.name.split('.')[0];
                 var reader=new FileReader();
                 reader.onload = function(e) {
                     treesArray = convertToJSON(reader.result);

--- a/viewtree.html
+++ b/viewtree.html
@@ -30,6 +30,9 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.)
             <div class="toolbar btn-initial" align="left">
                 <input type="button" tabindex="-1" value="clear" onClick="clearTree()" />
             </div>
+            <div id="conlluFileNameDiv">
+                <p id="conlluFileName"></p>
+            </div>
             <div style="width:50px">
                 <p id="currentTreeNumber" onClick="goToTreeToggle()"></p>
             </div>
@@ -79,7 +82,7 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.)
         <section id="download">
             <form id="download">
                 <p>Please select a filename:</p>
-                <input type="text" id="filename" value="treeOutputFile"/>
+                <input type="text" id="filename"/>
             </form>
             <input type="button" id="dwnbtn" value="Download" onClick="downloadTree()"/>
             <button onClick="hideAllWindows()">Close</button>


### PR DESCRIPTION
File name now shows on the toolbar. When downloading the file, the file name is used as a placeholder as well.