### PR TITLE
can now handle dots in the file name

### DIFF
--- a/main.js
+++ b/main.js
@@ -687,8 +687,14 @@ var setJSONtreeData = function() {
             readConfigFile();
             for (var i = 0; i < x.files.length; i++) {
                 var file = x.files[i];
-                file_name_elem.innerHTML = file.name.split('.')[0];
-                output_file_name_elem.value = file.name.split('.')[0];
+                if (!file.name.endsWith('.conllu')) {
+                    alert('File does not end with the .conllu extension, this will automatically be added when the file is saved.');
+                    file_name_elem.innerHTML = file.name;
+                    output_file_name_elem.value = file.name;
+                } else {
+                    file_name_elem.innerHTML = file.name.replace(/.conllu$/, '');
+                    output_file_name_elem.value = file.name.replace(/.conllu$/, '');
+                }
                 var reader=new FileReader();
                 reader.onload = function(e) {
                     treesArray = convertToJSON(reader.result);


### PR DESCRIPTION
Can now handle a file name containing multiple dots.
If the file name does not end with the extension .conllu, a warning message will be displayed saying that the file will automatically be saved with this extension.