### PR TITLE
file name automatically changes size

### DIFF
--- a/main.css
+++ b/main.css
@@ -203,14 +203,14 @@ li #faq {
     vertical-align:middle;
     cursor:pointer;
 }
-.navbar #conlluFileNameDiv {
+#conlluFileNameDiv {
     margin: 10px 15px 10px 4px;
 }
 
-.navbar #conlluFileName {
+#conlluFileName {
     color: #fff;
     font-family: 'bebas';
-    font-size: 14px;
+    font-size: 0.8vw;
     width: 200%;
 }
 


### PR DESCRIPTION
Changed file name font size style; now uses vw. This prevents the name from overflowing into the tree number when the browser size changes.