### PR TITLE
reorganize nav bar and its related components

### DIFF
--- a/main.css
+++ b/main.css
@@ -193,24 +193,17 @@ li #faq {
     vertical-align:middle;
 }
 
-/* navigation menu logo */
-.navbar #currentTreeNumber {
-    color: #fff;
-    font-family: 'bebas';
-    font-size: 18px;
-    margin: 20px 15px 0px 40px;
-    display: inline-block; 
-    vertical-align:middle;
-    cursor:pointer;
-}
 #conlluFileNameDiv {
-    margin: 10px 15px 10px 4px;
+    margin-top: 6px;
+    margin-left: 6px;
+    height: 65px;
+    color: white;
 }
 
-#conlluFileName {
+#conlluFileName #currentTreeNumber{
     color: #fff;
     font-family: 'bebas';
-    font-size: 0.8vw;
+    font-size: 0.9vw;
     width: 200%;
 }
 
@@ -341,6 +334,39 @@ body.viewtree {
     display: none;
 }
 
+.dropdown {
+    font-size: 15px;
+    color: white;
+    cursor: pointer;
+    display: none;
+}
+.dropdown .dropbtn {
+    font-size: 1.2vw;
+    border: none;
+    outline: none;
+    color: white;
+    /* padding: 14px 16px; */
+    background-color: inherit;
+    font-family: inherit; /* Important for vertical align on mobile phones */
+    margin: 0; /* Important for vertical align on mobile phones */
+}
+.dropdown-content {
+    display: none;
+    position: absolute;
+    background-color: white;
+    min-width: 160px;
+    box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+    z-index: 1;
+}
+.dropdown:hover .dropdown-content {
+    display: block;
+}
+.dropdown p {
+    padding-left: 6px;
+    color: #000;
+    font-size: 1.2vw;
+}
+
 /* toolbar buttons (when hovered) */
 .toolbar input:hover {
     background: #fff;
@@ -428,10 +454,9 @@ section textarea {
 #sents hr {
     display: block;
     height: 1px;
-    width: 90%;
+    width: 100%;
     border: 0;
     border-top: 1px solid #ccc;
-    margin: 1em 20;
     padding: 0px 0px;
 }
 

--- a/main.css
+++ b/main.css
@@ -194,16 +194,17 @@ li #faq {
 }
 
 #conlluFileNameDiv {
+    padding-top: 1vh;
     margin-top: 6px;
     margin-left: 6px;
     height: 65px;
     color: white;
+    font-size: 1.2em;
+    font-family: 'bebas';
 }
 
 #conlluFileName #currentTreeNumber{
     color: #fff;
-    font-family: 'bebas';
-    font-size: 0.9vw;
     width: 200%;
 }
 
@@ -335,19 +336,19 @@ body.viewtree {
 }
 
 .dropdown {
-    font-size: 15px;
+    /* font-size: 15px; */
     color: white;
     cursor: pointer;
     display: none;
 }
 .dropdown .dropbtn {
-    font-size: 1.2vw;
+    font-size: 0.9em;
     border: none;
     outline: none;
     color: white;
     /* padding: 14px 16px; */
     background-color: inherit;
-    font-family: inherit; /* Important for vertical align on mobile phones */
+    font-family: 'bebas';
     margin: 0; /* Important for vertical align on mobile phones */
 }
 .dropdown-content {
@@ -357,6 +358,7 @@ body.viewtree {
     min-width: 160px;
     box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
     z-index: 1;
+    font-size: 0.9em;
 }
 .dropdown:hover .dropdown-content {
     display: block;
@@ -364,7 +366,6 @@ body.viewtree {
 .dropdown p {
     padding-left: 6px;
     color: #000;
-    font-size: 1.2vw;
 }
 
 /* toolbar buttons (when hovered) */

--- a/main.js
+++ b/main.js
@@ -2574,7 +2574,7 @@ var getTree = function (treeData) {
     fullSen.innerHTML = addEngBdiToNum(fullSen.innerHTML);
 
     $("#sents").show();
-    $(".toolbar input").show();
+    $(".toolbar .dropdown").show();
 
     // force full tree redraw to update dynamic changes like doubleclick etc.
     fullTree.selectAll(".node").remove();

--- a/viewtree.html
+++ b/viewtree.html
@@ -25,32 +25,67 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.)
 <body class="viewtree">
       
     <div class="navbar">
-        <div class="container">
-            <a href="index.html"><img src="fonts/logo.png" alt="palmyra" id='logo'/></a>
-            <div class="toolbar btn-initial" align="left">
-                <input type="button" tabindex="-1" value="clear" onClick="clearTree()" />
+        <div class="container" style="display: flex; flex-direction: row; justify-content: flex-start; height: 65px">
+            <div class="logo" style="float: left">
+                <a href="index.html"><img src="fonts/logo.png" alt="palmyra" id='logo'/></a>
             </div>
-            <div id="conlluFileNameDiv">
-                <p id="conlluFileName"></p>
-            </div>
-            <div style="width:50px">
-                <p id="currentTreeNumber" onClick="goToTreeToggle()"></p>
-            </div>
-            <div class="toolbar btn-nav" align="center">
-                <input type="button" tabindex="-1" value="&#x21E4" onClick="firstTree()"/>
-                <input type="button" tabindex="-1" value="&#x2190" onClick="prevTree()"/>
-                <input type="button" tabindex="-1" value="&#x2192" onClick="nextTree()"/>
-                <input type="button" tabindex="-1" value="&#x21E5" onClick="lastTree()"/>
-            </div>
-            
-            <div class="toolbar btn-options" align="right">
-                <input type="button" tabindex="-1" value="+ Tree" onClick="addNewTree()"/>
-                <input type="button" tabindex="-1" value="- Tree" onClick="deleteCurrentTree()"/>
-                <input type="button" tabindex="-1" id="editbtn" value="edit" onClick="editToggle()"/>
-                <input type="button" tabindex="-1" value="download" onClick="downloadToggle()"/>
-                <input type="button" tabindex="-1" value="direction" onClick="directionToggle()"/>
-                <input type="button" tabindex="-1" value="tags" onClick="tagsToggle()" />
-                <input type="button" tabindex="-1" value="listing" onClick="search(treesArray)" id = "listingBtn"/>
+            <div class="toolbar" style="display: flex;flex-direction: column;margin-left: 20px;height: 65px">
+                <div id="conlluFileNameDiv">
+                    <span id="conlluFileName"></span>
+                    <span id="currentTreeNumber"></span>
+                </div>
+                <div class="toolbar btn-options" align="left" style="display: flex;justify-content: flex-start;align-items: center;">
+                    <div class="dropdown">
+                        <button class="dropbtn">File
+                          <i class="fa fa-caret-down"></i>
+                        </button>
+                        <div class="dropdown-content">
+                          <p>Save<p>
+                          <p>Save As</p>
+                          <p onClick="downloadToggle()">Download</p>
+                        </div>
+                    </div>
+                    <div class="dropdown">
+                        <button class="dropbtn">Edit
+                          <i class="fa fa-caret-down"></i>
+                        </button>
+                        <div class="dropdown-content">
+                          <p onClick="editToggle()">Edit Morphology<p>
+                          <p onClick="tagsToggle()">Edit Tags</p>
+                          <p onClick="addNewTree()">Add New Tree</p>
+                          <p onClick="deleteCurrentTree()">Delete Current Tree</p>
+                          <p onClick="clearTree()">Clear</p>
+                        </div>
+                    </div>
+                    <div class="dropdown">
+                        <button class="dropbtn">View
+                          <i class="fa fa-caret-down"></i>
+                        </button>
+                        <div class="dropdown-content">
+                          <p onClick="directionToggle()">Change Direction<p>
+                          <p onClick="search(treesArray)">Listing</p>
+                        </div>
+                    </div>
+                    <div class="dropdown">
+                        <button class="dropbtn">Go
+                          <i class="fa fa-caret-down"></i>
+                        </button>
+                        <div class="dropdown-content">
+                          <p onClick="firstTree()">First Tree<p>
+                          <p onClick="prevTree()">Previous Tree</p>
+                          <p onClick="nextTree()">Next Tree</p>
+                          <p onClick="lastTree()">Last Tree</p>
+                          <p onClick="goToTreeToggle()">Use Tree Number</p>
+                        </div>
+                    </div>
+                    <!-- <div class="dropdown">
+                        <button class="dropbtn">Help
+                          <i class="fa fa-caret-down"></i>
+                        </button>
+                        <div class="dropdown-content">
+                        </div>
+                    </div> -->
+                </div>
             </div>
         </div>
 


### PR DESCRIPTION
The new screen now looks as follows
![Screen Shot 2023-05-04 at 11 56 03 AM](https://user-images.githubusercontent.com/46087559/236143951-b58011c8-8b68-4942-8bd8-2917969c1419.png)
![Screen Shot 2023-05-04 at 11 55 54 AM](https://user-images.githubusercontent.com/46087559/236143965-0d4cac3f-2058-49eb-b894-f7a634c37980.png)
![Screen Shot 2023-05-04 at 11 55 42 AM](https://user-images.githubusercontent.com/46087559/236143973-986d8450-2c00-4ba0-a754-1daa8e5b0e57.png)
![Screen Shot 2023-05-04 at 11 55 27 AM](https://user-images.githubusercontent.com/46087559/236143983-6845ca25-3324-418f-8922-0e681b80c3a6.png)

We will change up the design a little bit in other PRs, but I think this PR serves as the skeleton for the clean design that we are aiming for.
